### PR TITLE
Add admins

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,0 +1,1 @@
+POSTGRES_HOST=localhost

--- a/.env.test
+++ b/.env.test
@@ -1,0 +1,1 @@
+POSTGRES_HOST=localhost

--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,2 @@
+use flake
+export GEM_PATH=$(bundle env | grep "Gem Path" | sed -n "s/^\s*Gem Path\s*\(\S*\)/\1/p")

--- a/.gitignore
+++ b/.gitignore
@@ -7,8 +7,8 @@
 # Ignore bundler config.
 /.bundle
 
-# Ignore all environment files.
-/.env*
+# Ignore the local environment file.
+.env
 
 # Ignore all logfiles and tempfiles.
 /log/*
@@ -37,4 +37,3 @@
 !/app/assets/builds/.keep
 
 .direnv/*
-.envrc

--- a/Gemfile
+++ b/Gemfile
@@ -19,12 +19,6 @@ gem "tailwindcss-rails"
 # Build JSON APIs with ease [https://github.com/rails/jbuilder]
 gem "jbuilder"
 
-# Use Active Model has_secure_password [https://guides.rubyonrails.org/active_model_basics.html#securepassword]
-# gem "bcrypt", "~> 3.1.7"
-
-# Windows does not include zoneinfo files, so bundle the tzinfo-data gem
-gem "tzinfo-data", platforms: %i[ windows jruby ]
-
 # Use the database-backed adapters for Rails.cache, Active Job, and Action Cable
 gem "solid_cache"
 gem "solid_queue"
@@ -41,6 +35,12 @@ gem "thruster", require: false
 
 # Use Active Storage variants [https://guides.rubyonrails.org/active_storage_overview.html#transforming-images]
 # gem "image_processing", "~> 1.2"
+
+# Required by Rodauth
+gem "bcrypt", "~> 3.1"
+gem "rodauth-rails", "~> 2.0"
+gem "sequel-activerecord_connection", "~> 2.0"
+gem "tilt", "~> 2.4"
 
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -83,6 +83,7 @@ GEM
       uri (>= 0.13.1)
     ast (2.4.2)
     base64 (0.2.0)
+    bcrypt (3.1.20)
     bcrypt_pbkdf (1.1.1)
     bcrypt_pbkdf (1.1.1-arm64-darwin)
     bcrypt_pbkdf (1.1.1-x86_64-darwin)
@@ -247,6 +248,18 @@ GEM
     regexp_parser (2.9.3)
     reline (0.6.0)
       io-console (~> 0.5)
+    roda (3.86.0)
+      rack
+    rodauth (2.37.0)
+      roda (>= 2.6.0)
+      sequel (>= 4)
+    rodauth-model (0.3.0)
+      rodauth (~> 2.28)
+    rodauth-rails (2.0.0)
+      railties (>= 5.0, < 8.1)
+      roda (~> 3.76)
+      rodauth (~> 2.36)
+      rodauth-model (~> 0.2)
     rspec-core (3.13.2)
       rspec-support (~> 3.13.0)
     rspec-expectations (3.13.3)
@@ -296,6 +309,11 @@ GEM
       rubocop (~> 1.61)
     ruby-progressbar (1.13.0)
     securerandom (0.4.1)
+    sequel (5.87.0)
+      bigdecimal
+    sequel-activerecord_connection (2.0.0)
+      activerecord (>= 5.0, < 8.1)
+      sequel (~> 5.38)
     shoulda-matchers (6.4.0)
       activesupport (>= 5.2.0)
     solid_cable (3.0.4)
@@ -338,6 +356,7 @@ GEM
     thruster (0.1.9-arm64-darwin)
     thruster (0.1.9-x86_64-darwin)
     thruster (0.1.9-x86_64-linux)
+    tilt (2.4.0)
     timeout (0.4.3)
     turbo-rails (2.0.11)
       actionpack (>= 6.0.0)
@@ -369,6 +388,7 @@ PLATFORMS
 
 DEPENDENCIES
   annotate!
+  bcrypt (~> 3.1)
   bootsnap
   brakeman
   debug
@@ -382,9 +402,11 @@ DEPENDENCIES
   propshaft
   puma (>= 5.0)
   rails (~> 8.0.1)
+  rodauth-rails (~> 2.0)
   rspec-rails (~> 7.1)
   rubocop-rails-omakase
   rubocop-rspec (~> 3.3)
+  sequel-activerecord_connection (~> 2.0)
   shoulda-matchers (~> 6.4)
   solid_cable
   solid_cache
@@ -392,8 +414,8 @@ DEPENDENCIES
   stimulus-rails
   tailwindcss-rails
   thruster
+  tilt (~> 2.4)
   turbo-rails
-  tzinfo-data
   web-console
 
 BUNDLED WITH

--- a/app/auth/rodauth_admin.rb
+++ b/app/auth/rodauth_admin.rb
@@ -1,0 +1,147 @@
+require "sequel/core"
+
+class RodauthAdmin < Rodauth::Rails::Auth
+  configure do
+    # List of authentication features that are loaded.
+    enable :login, :logout, :remember
+
+    # See the Rodauth documentation for the list of available config options:
+    # http://rodauth.jeremyevans.net/documentation.html
+
+    # ==> General
+    # Initialize Sequel and have it reuse Active Record's database connection.
+    db Sequel.postgres(extensions: :activerecord_connection, keep_reference: false)
+    # Avoid DB query that checks accounts table schema at boot time.
+    convert_token_id_to_integer? { Account.columns_hash["id"].type == :integer }
+
+    # Change prefix of table and foreign key column names from default "account"
+    # accounts_table :users
+    # verify_account_table :user_verification_keys
+    # verify_login_change_table :user_login_change_keys
+    # reset_password_table :user_password_reset_keys
+    # remember_table :user_remember_keys
+
+    # The secret key used for hashing public-facing tokens for various features.
+    # Defaults to Rails `secret_key_base`, but you can use your own secret key.
+    # hmac_secret "94257aebfb2684b06ad402b6e13a40bd924a2608cc9c39bb8a9f6b241eeb67ccd124ce40100d8e155e71a6bd44f5bfe64dffe49ecdaac5b15708003a3d8a3314"
+
+    # Use path prefix for all routes.
+    prefix "/auth/admin"
+
+    # Specify the controller used for view rendering, CSRF, and callbacks.
+    rails_controller { Admin::RodauthController }
+
+    # Make built-in page titles accessible in your views via an instance variable.
+    title_instance_variable :@page_title
+
+    # Store account status in an integer column without foreign key constraint.
+    account_status_column :status
+
+    # Store password hash in a column instead of a separate table.
+    account_password_hash_column :password_hash
+
+    # Set password when creating account instead of when verifying.
+    # verify_account_set_password? false
+
+    # Change some default param keys.
+    login_param "email"
+    # login_confirm_param "email-confirm"
+    # password_confirm_param "confirm_password"
+
+    # Redirect back to originally requested location after authentication.
+    login_return_to_requested_location? true
+    # two_factor_auth_return_to_requested_location? true # if using MFA
+
+    # Autologin the user after they have reset their password.
+    # reset_password_autologin? true
+
+    # Delete the account record when the user has closed their account.
+    # delete_account_on_close? true
+
+    # Redirect to the app from login and registration pages if already logged in.
+    already_logged_in { redirect login_redirect }
+
+    # ==> Emails
+    send_email do |email|
+      # queue email delivery on the mailer after the transaction commits
+      db.after_commit { email.deliver_later }
+    end
+
+    # ==> Flash
+    # Match flash keys with ones already used in the Rails app.
+    # flash_notice_key :success # default is :notice
+    # flash_error_key :error # default is :alert
+
+    # Override default flash messages.
+    # create_account_notice_flash "Your account has been created. Please verify your account by visiting the confirmation link sent to your email address."
+    # require_login_error_flash "Login is required for accessing this page"
+    # login_notice_flash nil
+
+    # ==> Validation
+    # Override default validation error messages.
+    # no_matching_login_message "user with this email address doesn't exist"
+    # already_an_account_with_this_login_message "user with this email address already exists"
+    # password_too_short_message { "needs to have at least #{password_minimum_length} characters" }
+    # login_does_not_meet_requirements_message { "invalid email#{", #{login_requirement_message}" if login_requirement_message}" }
+
+    # Passwords shorter than 8 characters are considered weak according to OWASP.
+    # password_minimum_length 8
+    # bcrypt has a maximum input length of 72 bytes, truncating any extra bytes.
+    # password_maximum_bytes 72
+
+    # Custom password complexity requirements (alternative to password_complexity feature).
+    # password_meets_requirements? do |password|
+    #   super(password) && password_complex_enough?(password)
+    # end
+    # auth_class_eval do
+    #   def password_complex_enough?(password)
+    #     return true if password.match?(/\d/) && password.match?(/[^a-zA-Z\d]/)
+    #     set_password_requirement_error_message(:password_simple, "requires one number and one special character")
+    #     false
+    #   end
+    # end
+
+    # ==> Remember Feature
+    # Remember all logged in users.
+    after_login { remember_login }
+
+    # Or only remember users that have ticked a "Remember Me" checkbox on login.
+    # after_login { remember_login if param_or_nil("remember") }
+
+    # Extend user's remember period when remembered via a cookie
+    extend_remember_deadline? true
+
+    # ==> Hooks
+    # Validate custom fields in the create account form.
+    # before_create_account do
+    #   throw_error_status(422, "name", "must be present") if param("name").empty?
+    # end
+
+    # Perform additional actions after the account is created.
+    # after_create_account do
+    #   Profile.create!(account_id: account_id, name: param("name"))
+    # end
+
+    # Do additional cleanup after the account is closed.
+    # after_close_account do
+    #   Profile.find_by!(account_id: account_id).destroy
+    # end
+
+    # ==> Redirects
+    # Redirect to home page after logout.
+    logout_redirect "/"
+
+    # Redirect to wherever login redirects to after account verification.
+    # verify_account_redirect { login_redirect }
+
+    # Redirect to login page after password reset.
+    # reset_password_redirect { login_path }
+
+    # ==> Deadlines
+    # Change default deadlines for some actions.
+    # verify_account_grace_period 3.days.to_i
+    # reset_password_deadline_interval Hash[hours: 6]
+    # verify_login_change_deadline_interval Hash[days: 2]
+    # remember_deadline_interval Hash[days: 30]
+  end
+end

--- a/app/auth/rodauth_app.rb
+++ b/app/auth/rodauth_app.rb
@@ -1,0 +1,20 @@
+class RodauthApp < Rodauth::Rails::App
+  # primary configuration
+  # Not needed yet
+  # configure RodauthMain
+
+  # secondary configuration
+  configure RodauthAdmin, :admin
+
+  route do |r|
+    # rodauth.load_memory # autologin remembered users
+
+    # r.rodauth
+    r.rodauth(:admin)
+
+    # authenticate /admin/* requests
+    if r.path.start_with?("/admin")
+      rodauth(:admin).require_account
+    end
+  end
+end

--- a/app/controllers/admin/posts_controller.rb
+++ b/app/controllers/admin/posts_controller.rb
@@ -26,11 +26,11 @@ module Admin
 
       respond_to do |format|
         if @post.save
-          format.html { redirect_to @post, notice: "Post was successfully created." }
-          format.json { render :show, status: :created, location: @post }
+          format.html {
+            redirect_to admin_post_path(@post), notice: "Post was successfully created."
+          }
         else
           format.html { render :new, status: :unprocessable_entity }
-          format.json { render json: @post.errors, status: :unprocessable_entity }
         end
       end
     end
@@ -42,10 +42,8 @@ module Admin
           format.html {
             redirect_to admin_post_path(@post), notice: "Post was successfully updated."
           }
-          format.json { render :show, status: :ok, location: @post }
         else
           format.html { render :edit, status: :unprocessable_entity }
-          format.json { render json: @post.errors, status: :unprocessable_entity }
         end
       end
     end
@@ -55,8 +53,9 @@ module Admin
       @post.destroy!
 
       respond_to do |format|
-        format.html { redirect_to posts_path, status: :see_other, notice: "Post got destroyed." }
-        format.json { head :no_content }
+        format.html {
+          redirect_to admin_posts_path, status: :see_other, notice: "Post got destroyed."
+        }
       end
     end
 

--- a/app/controllers/admin/posts_controller.rb
+++ b/app/controllers/admin/posts_controller.rb
@@ -1,6 +1,5 @@
 module Admin
   class PostsController < ApplicationController
-    before_action :authenticate_admin
     before_action :set_post, only: %i[ show edit update destroy ]
 
     # GET /posts or /posts.json
@@ -40,7 +39,9 @@ module Admin
     def update
       respond_to do |format|
         if @post.update(post_params)
-          format.html { redirect_to @post, notice: "Post was successfully updated." }
+          format.html {
+            redirect_to admin_post_path(@post), notice: "Post was successfully updated."
+          }
           format.json { render :show, status: :ok, location: @post }
         else
           format.html { render :edit, status: :unprocessable_entity }

--- a/app/controllers/admin/rodauth_controller.rb
+++ b/app/controllers/admin/rodauth_controller.rb
@@ -1,0 +1,22 @@
+module Admin
+  class RodauthController < ApplicationController
+    # Used by Rodauth for rendering views, CSRF protection, running any
+    # registered action callbacks and rescue handlers, instrumentation etc.
+
+    # Controller callbacks and rescue handlers will run around Rodauth endpoints.
+    # before_action :verify_captcha, only: :login, if: -> { request.post? }
+    # rescue_from("SomeError") { |exception| ... }
+
+    # Layout can be changed for all Rodauth pages or only certain pages.
+    # layout "authentication"
+    # layout -> do
+    #   case rodauth.current_route
+    #   when :login, :create_account, :verify_account, :verify_account_resend,
+    #        :reset_password, :reset_password_request
+    #     "authentication"
+    #   else
+    #     "application"
+    #   end
+    # end
+  end
+end

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -1,0 +1,17 @@
+# == Schema Information
+#
+# Table name: accounts
+#
+#  id            :bigint           not null, primary key
+#  email         :citext           not null
+#  password_hash :string
+#  status        :integer          default(1), not null
+#
+# Indexes
+#
+#  index_accounts_on_email  (email) UNIQUE WHERE (status = ANY (ARRAY[1, 2]))
+#
+class Account < ApplicationRecord
+  include Rodauth::Rails.model(:admin)
+  enum :status, { unverified: 1, verified: 2, closed: 3 }
+end

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -5,7 +5,7 @@
 #  id            :bigint           not null, primary key
 #  email         :citext           not null
 #  password_hash :string
-#  status        :integer          default(1), not null
+#  status        :integer          default("unverified"), not null
 #
 # Indexes
 #

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -25,6 +25,10 @@ class Post < ApplicationRecord
   scope :published, -> { where.not(published_at: nil) }
 
   validates :title, :summary, :body, presence: true, if: :published?
+  validates :published_at, comparison: {
+    less_than_or_equal_to: -> { Time.current },
+    message: "cannot be in the future"
+  }, allow_nil: true
   validates :ref, presence: true, uniqueness: true
   validates :visitor_count, numericality: { greater_than_or_equal_to: 0 }
 

--- a/app/views/admin/posts/_form.html.erb
+++ b/app/views/admin/posts/_form.html.erb
@@ -1,4 +1,4 @@
-<%= form_with(model: post, url: admin_post_path(post), class: "contents") do |form| %>
+<%= form_with(model: [:admin, post], class: "contents") do |form| %>
   <% if post.errors.any? %>
     <div id="error_explanation" class="bg-red-50 text-red-500 px-3 py-2 font-medium rounded-lg mt-3">
       <h2><%= pluralize(post.errors.count, "error") %> prohibited this post from being saved:</h2>

--- a/app/views/admin/posts/_form.html.erb
+++ b/app/views/admin/posts/_form.html.erb
@@ -1,4 +1,4 @@
-<%= form_with(model: post, class: "contents") do |form| %>
+<%= form_with(model: post, url: admin_post_path(post), class: "contents") do |form| %>
   <% if post.errors.any? %>
     <div id="error_explanation" class="bg-red-50 text-red-500 px-3 py-2 font-medium rounded-lg mt-3">
       <h2><%= pluralize(post.errors.count, "error") %> prohibited this post from being saved:</h2>

--- a/app/views/admin/posts/_post.html.erb
+++ b/app/views/admin/posts/_post.html.erb
@@ -1,0 +1,22 @@
+<div id="<%= dom_id post %>">
+  <p class="my-5">
+    <strong class="block font-medium mb-1">Title:</strong>
+    <%= post.title %>
+  </p>
+
+  <p class="my-5">
+    <strong class="block font-medium mb-1">Summary:</strong>
+    <%= post.summary %>
+  </p>
+
+  <p class="my-5">
+    <strong class="block font-medium mb-1">Body:</strong>
+    <%= post.body %>
+  </p>
+
+  <p class="my-5">
+    <strong class="block font-medium mb-1">Published at:</strong>
+    <%= post.published_at %>
+  </p>
+
+</div>

--- a/app/views/admin/posts/_post_card.html.erb
+++ b/app/views/admin/posts/_post_card.html.erb
@@ -1,0 +1,17 @@
+<div id="<%= dom_id post %>">
+  <p class="my-5">
+    <strong class="block font-medium mb-1">Title:</strong>
+    <%= post.title %>
+  </p>
+
+  <p class="my-5">
+    <strong class="block font-medium mb-1">Summary:</strong>
+    <%= post.summary %>
+  </p>
+
+  <p class="my-5">
+    <strong class="block font-medium mb-1">Published at:</strong>
+    <%= post.published_at %>
+  </p>
+
+</div>

--- a/app/views/admin/posts/edit.html.erb
+++ b/app/views/admin/posts/edit.html.erb
@@ -3,6 +3,6 @@
 
   <%= render "form", post: @post %>
 
-  <%= link_to "Show this post", @post, class: "ml-2 rounded-lg py-3 px-5 bg-gray-100 inline-block font-medium" %>
-  <%= link_to "Back to posts", posts_path, class: "ml-2 rounded-lg py-3 px-5 bg-gray-100 inline-block font-medium" %>
+  <%= link_to "Show this post", admin_post_path(@post), class: "ml-2 rounded-lg py-3 px-5 bg-gray-100 inline-block font-medium" %>
+  <%= link_to "Back to posts", admin_posts_path, class: "ml-2 rounded-lg py-3 px-5 bg-gray-100 inline-block font-medium" %>
 </div>

--- a/app/views/admin/posts/index.html.erb
+++ b/app/views/admin/posts/index.html.erb
@@ -1,0 +1,19 @@
+<div class="w-full">
+  <% if notice.present? %>
+    <p class="py-2 px-3 bg-green-50 mb-5 text-green-500 font-medium rounded-lg inline-block" id="notice"><%= notice %></p>
+  <% end %>
+
+  <% content_for :title, "Posts" %>
+
+  <div id="posts" class="min-w-full">
+    <% @posts.each do |post| %>
+      <%= render "post_card", post: post %>
+      <p>
+        <%= link_to "Show this post", admin_post_path(post), class: "ml-2 rounded-lg py-3 px-5 bg-gray-100 inline-block font-medium" %>
+      </p>
+    <% end %>
+  </div>
+  <p>
+  <%= link_to "Log out", rodauth(:admin).logout_path, data: { turbo_method: :post }, class: "ml-2 rounded-lg py-3 px-5 bg-gray-100 inline-block font-medium" %>
+  </p>
+</div>

--- a/app/views/admin/posts/index.html.erb
+++ b/app/views/admin/posts/index.html.erb
@@ -13,7 +13,4 @@
       </p>
     <% end %>
   </div>
-  <p>
-  <%= link_to "Log out", rodauth(:admin).logout_path, data: { turbo_method: :post }, class: "ml-2 rounded-lg py-3 px-5 bg-gray-100 inline-block font-medium" %>
-  </p>
 </div>

--- a/app/views/admin/posts/new.html.erb
+++ b/app/views/admin/posts/new.html.erb
@@ -3,5 +3,5 @@
 
   <%= render "form", post: @post %>
 
-  <%= link_to "Back to posts", posts_path, class: "ml-2 rounded-lg py-3 px-5 bg-gray-100 inline-block font-medium" %>
+  <%= link_to "Back to posts", admin_posts_path, class: "ml-2 rounded-lg py-3 px-5 bg-gray-100 inline-block font-medium" %>
 </div>

--- a/app/views/admin/posts/show.html.erb
+++ b/app/views/admin/posts/show.html.erb
@@ -6,10 +6,10 @@
 
     <%= render @post %>
 
-    <%= link_to "Edit this post", edit_post_path(@post), class: "mt-2 rounded-lg py-3 px-5 bg-gray-100 inline-block font-medium" %>
-    <%= link_to "Back to posts", posts_path, class: "ml-2 rounded-lg py-3 px-5 bg-gray-100 inline-block font-medium" %>
+    <%= link_to "Edit this post", edit_admin_post_path(@post), class: "mt-2 rounded-lg py-3 px-5 bg-gray-100 inline-block font-medium" %>
+    <%= link_to "Back to posts", admin_posts_path, class: "ml-2 rounded-lg py-3 px-5 bg-gray-100 inline-block font-medium" %>
     <div class="inline-block ml-2">
-      <%= button_to "Destroy this post", @post, method: :delete, class: "mt-2 rounded-lg py-3 px-5 bg-gray-100 font-medium" %>
+      <%= button_to "Destroy this post", admin_post_path(@post), method: :delete, class: "mt-2 rounded-lg py-3 px-5 bg-gray-100 font-medium" %>
     </div>
   </div>
 </div>

--- a/app/views/admin/posts/show.json.jbuilder
+++ b/app/views/admin/posts/show.json.jbuilder
@@ -1,0 +1,1 @@
+json.partial! "posts/post", post: @post

--- a/config/initializers/rodauth.rb
+++ b/config/initializers/rodauth.rb
@@ -1,0 +1,3 @@
+Rodauth::Rails.configure do |config|
+  config.app = "RodauthApp"
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,9 @@
 Rails.application.routes.draw do
   resources :posts, only: %i[index show]
-  # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
+
+  namespace :admin do
+    resources :posts
+  end
 
   # Reveal health status on /up that returns 200 if the app boots with no exceptions, otherwise 500.
   # Can be used by load balancers and uptime monitors to verify that the app is live.

--- a/db/migrate/20241217124513_create_rodauth.rb
+++ b/db/migrate/20241217124513_create_rodauth.rb
@@ -1,0 +1,48 @@
+class CreateRodauth < ActiveRecord::Migration[8.0]
+  def change
+    enable_extension "citext"
+
+    create_table :accounts do |t|
+      t.integer :status, null: false, default: 1
+      t.citext :email, null: false
+      t.check_constraint "email ~ '^[^,;@ \r\n]+@[^,@; \r\n]+\.[^,@; \r\n]+$'", name: "valid_email"
+      t.index :email, unique: true, where: "status IN (1, 2)"
+      t.string :password_hash
+    end
+
+    # Used by the password reset feature
+    create_table :account_password_reset_keys, id: false do |t|
+      t.bigint :id, primary_key: true
+      t.foreign_key :accounts, column: :id
+      t.string :key, null: false
+      t.datetime :deadline, null: false
+      t.datetime :email_last_sent, null: false, default: -> { "CURRENT_TIMESTAMP" }
+    end
+
+    # Used by the account verification feature
+    create_table :account_verification_keys, id: false do |t|
+      t.bigint :id, primary_key: true
+      t.foreign_key :accounts, column: :id
+      t.string :key, null: false
+      t.datetime :requested_at, null: false, default: -> { "CURRENT_TIMESTAMP" }
+      t.datetime :email_last_sent, null: false, default: -> { "CURRENT_TIMESTAMP" }
+    end
+
+    # Used by the verify login change feature
+    create_table :account_login_change_keys, id: false do |t|
+      t.bigint :id, primary_key: true
+      t.foreign_key :accounts, column: :id
+      t.string :key, null: false
+      t.string :login, null: false
+      t.datetime :deadline, null: false
+    end
+
+    # Used by the remember me feature
+    create_table :account_remember_keys, id: false do |t|
+      t.bigint :id, primary_key: true
+      t.foreign_key :accounts, column: :id
+      t.string :key, null: false
+      t.datetime :deadline, null: false
+    end
+  end
+end

--- a/db/migrate/20241217124513_create_rodauth.rb
+++ b/db/migrate/20241217124513_create_rodauth.rb
@@ -10,33 +10,6 @@ class CreateRodauth < ActiveRecord::Migration[8.0]
       t.string :password_hash
     end
 
-    # Used by the password reset feature
-    create_table :account_password_reset_keys, id: false do |t|
-      t.bigint :id, primary_key: true
-      t.foreign_key :accounts, column: :id
-      t.string :key, null: false
-      t.datetime :deadline, null: false
-      t.datetime :email_last_sent, null: false, default: -> { "CURRENT_TIMESTAMP" }
-    end
-
-    # Used by the account verification feature
-    create_table :account_verification_keys, id: false do |t|
-      t.bigint :id, primary_key: true
-      t.foreign_key :accounts, column: :id
-      t.string :key, null: false
-      t.datetime :requested_at, null: false, default: -> { "CURRENT_TIMESTAMP" }
-      t.datetime :email_last_sent, null: false, default: -> { "CURRENT_TIMESTAMP" }
-    end
-
-    # Used by the verify login change feature
-    create_table :account_login_change_keys, id: false do |t|
-      t.bigint :id, primary_key: true
-      t.foreign_key :accounts, column: :id
-      t.string :key, null: false
-      t.string :login, null: false
-      t.datetime :deadline, null: false
-    end
-
     # Used by the remember me feature
     create_table :account_remember_keys, id: false do |t|
       t.bigint :id, primary_key: true

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,41 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2024_12_16_114348) do
+ActiveRecord::Schema[8.0].define(version: 2024_12_17_124513) do
   # These are extensions that must be enabled in order to support this database
+  enable_extension "citext"
   enable_extension "pg_catalog.plpgsql"
+
+  create_table "account_login_change_keys", force: :cascade do |t|
+    t.string "key", null: false
+    t.string "login", null: false
+    t.datetime "deadline", null: false
+  end
+
+  create_table "account_password_reset_keys", force: :cascade do |t|
+    t.string "key", null: false
+    t.datetime "deadline", null: false
+    t.datetime "email_last_sent", default: -> { "CURRENT_TIMESTAMP" }, null: false
+  end
+
+  create_table "account_remember_keys", force: :cascade do |t|
+    t.string "key", null: false
+    t.datetime "deadline", null: false
+  end
+
+  create_table "account_verification_keys", force: :cascade do |t|
+    t.string "key", null: false
+    t.datetime "requested_at", default: -> { "CURRENT_TIMESTAMP" }, null: false
+    t.datetime "email_last_sent", default: -> { "CURRENT_TIMESTAMP" }, null: false
+  end
+
+  create_table "accounts", force: :cascade do |t|
+    t.integer "status", default: 1, null: false
+    t.citext "email", null: false
+    t.string "password_hash"
+    t.index ["email"], name: "index_accounts_on_email", unique: true, where: "(status = ANY (ARRAY[1, 2]))"
+    t.check_constraint "email ~ '^[^,;@ \r\n]+@[^,@; \r\n]+.[^,@; \r\n]+$'::citext", name: "valid_email"
+  end
 
   create_table "posts", force: :cascade do |t|
     t.string "title"
@@ -27,4 +59,9 @@ ActiveRecord::Schema[8.0].define(version: 2024_12_16_114348) do
     t.index ["published_at"], name: "index_posts_on_published_at"
     t.index ["ref"], name: "index_posts_on_ref", unique: true
   end
+
+  add_foreign_key "account_login_change_keys", "accounts", column: "id"
+  add_foreign_key "account_password_reset_keys", "accounts", column: "id"
+  add_foreign_key "account_remember_keys", "accounts", column: "id"
+  add_foreign_key "account_verification_keys", "accounts", column: "id"
 end

--- a/spec/factories/account.rb
+++ b/spec/factories/account.rb
@@ -1,0 +1,11 @@
+FactoryBot.define do
+  factory :account do
+    email { Faker::Internet.email }
+    password_hash { BCrypt::Password.create(password).to_s }
+    status { :verified }
+
+    transient do
+      password { SecureRandom.hex(7) }
+    end
+  end
+end

--- a/spec/models/post_spec.rb
+++ b/spec/models/post_spec.rb
@@ -40,6 +40,12 @@ RSpec.describe Post, type: :model do
 
     it { is_expected.to validate_numericality_of(:visitor_count).is_greater_than_or_equal_to(0) }
 
+    it 'must be published in the past' do
+      post.published_at = 3.hours.from_now
+      post.valid?
+      expect(post.errors.messages[:published_at]).to include(/cannot be in the future/)
+    end
+
     describe ':ref' do
       # For these specs the post must be persisted, otherwise 'ref' is generated
       subject(:post) { create(:post) }

--- a/spec/requests/admin/posts_spec.rb
+++ b/spec/requests/admin/posts_spec.rb
@@ -1,0 +1,75 @@
+require 'rails_helper'
+
+RSpec.describe "/admin/posts", type: :request do
+  context "when no admin is logged in" do
+    let(:post) { create(:post) }
+
+    describe "GET /index" do
+      it "redirects to the login page" do
+        get admin_posts_url
+        expect(response).to redirect_to('/auth/admin/login')
+      end
+    end
+
+    describe "GET /show" do
+      it "redirects to the login page" do
+        get admin_post_url(post)
+        expect(response).to redirect_to('/auth/admin/login')
+      end
+    end
+
+    describe "GET /new" do
+      it "redirects to the login page" do
+        get new_admin_post_url(post)
+        expect(response).to redirect_to('/auth/admin/login')
+      end
+    end
+
+    describe "GET /edit" do
+      it "redirects to the login page" do
+        get edit_admin_post_url(post)
+        expect(response).to redirect_to('/auth/admin/login')
+      end
+    end
+  end
+
+  context "when an admin is logged in" do
+    include_context 'admin logged in'
+
+    let(:record) { create(:post) }
+
+    describe "GET /index" do
+      before { create_list(:post, 5, :published) }
+
+      it "renders a successful response" do
+        get admin_posts_url
+        expect(response).to be_successful
+      end
+    end
+
+    describe "GET /show" do
+      it "renders a successful response" do
+        get admin_post_url(record)
+        expect(response).to be_successful
+      end
+
+      it "does not change the visitor count" do
+        expect { get admin_post_url(record) }.not_to change { record.reload.visitor_count }
+      end
+    end
+
+    describe "GET /new" do
+      it "renders a successful response" do
+        get new_admin_post_url
+        expect(response).to be_successful
+      end
+    end
+
+    describe "GET /edit" do
+      it "renders a successful response" do
+        get edit_admin_post_url(record)
+        expect(response).to be_successful
+      end
+    end
+  end
+end

--- a/spec/requests/admin/posts_spec.rb
+++ b/spec/requests/admin/posts_spec.rb
@@ -1,9 +1,30 @@
 require 'rails_helper'
 
 RSpec.describe "/admin/posts", type: :request do
-  context "when no admin is logged in" do
-    let(:post) { create(:post) }
+  let(:valid_attributes) do
+    {
+      title: 'Original Title',
+      summary: 'Original Summary',
+      body: 'Original Body'
+    }
+  end
+  let(:invalid_attributes) do
+    {
+      title: '',
+      summary: ''
+    }
+  end
+  let(:new_attributes) do
+    {
+      title: 'New Title',
+      summary: 'New Summary',
+      body: 'New Body'
+    }
+  end
 
+  let(:record) { create(:post, **valid_attributes) }
+
+  context "when no admin is logged in" do
     describe "GET /index" do
       it "redirects to the login page" do
         get admin_posts_url
@@ -13,21 +34,60 @@ RSpec.describe "/admin/posts", type: :request do
 
     describe "GET /show" do
       it "redirects to the login page" do
-        get admin_post_url(post)
+        get admin_post_url(record)
         expect(response).to redirect_to('/auth/admin/login')
       end
     end
 
     describe "GET /new" do
       it "redirects to the login page" do
-        get new_admin_post_url(post)
+        get new_admin_post_url(record)
         expect(response).to redirect_to('/auth/admin/login')
       end
     end
 
     describe "GET /edit" do
       it "redirects to the login page" do
-        get edit_admin_post_url(post)
+        get edit_admin_post_url(record)
+        expect(response).to redirect_to('/auth/admin/login')
+      end
+    end
+
+    describe "POST /create" do
+      it "does not create a new Post" do
+        expect {
+          post admin_posts_url, params: { post: valid_attributes }
+        }.not_to change(Post, :count)
+      end
+
+      it "redirects to the login page" do
+        post admin_posts_url, params: { post: valid_attributes }
+        expect(response).to redirect_to('/auth/admin/login')
+      end
+    end
+
+    describe "PATCH /update" do
+      it "does not update the requested post" do
+        patch admin_post_url(record), params: { post: new_attributes }
+        expect(record.reload.title).to eq('Original Title')
+      end
+
+      it "redirects to the login page" do
+        patch admin_post_url(record), params: { post: new_attributes }
+        expect(response).to redirect_to('/auth/admin/login')
+      end
+    end
+
+    describe "DELETE /destroy" do
+      it "does not destroy the requested post" do
+        record
+        expect {
+          delete admin_post_url(record)
+        }.not_to change(Post, :count)
+      end
+
+      it "redirects to the login page" do
+        delete admin_post_url(record)
         expect(response).to redirect_to('/auth/admin/login')
       end
     end
@@ -69,6 +129,58 @@ RSpec.describe "/admin/posts", type: :request do
       it "renders a successful response" do
         get edit_admin_post_url(record)
         expect(response).to be_successful
+      end
+    end
+
+    describe "POST /create" do
+      context "with valid parameters" do
+        it "creates a new Post" do
+          expect {
+            post admin_posts_url, params: { post: valid_attributes }
+          }.to change(Post, :count).by(1)
+        end
+
+        it "redirects to the created post" do
+          post admin_posts_url, params: { post: valid_attributes }
+          expect(response).to redirect_to(admin_post_url(Post.last))
+        end
+      end
+    end
+
+    describe "PATCH /update" do
+      let(:record) { create(:post, :published, **valid_attributes) }
+
+      context "with valid parameters" do
+        it "updates the requested post" do
+          patch admin_post_url(record), params: { post: new_attributes }
+          expect(record.reload).to have_attributes(new_attributes)
+        end
+
+        it "redirects to the post" do
+          patch admin_post_url(record), params: { post: new_attributes }
+          expect(response).to redirect_to(admin_post_url(record))
+        end
+      end
+
+      context "with invalid parameters" do
+        it "renders a response with 422 status (i.e. to display the 'edit' template)" do
+          patch admin_post_url(record), params: { post: invalid_attributes }
+          expect(response).to have_http_status(:unprocessable_entity)
+        end
+      end
+    end
+
+    describe "DELETE /destroy" do
+      it "destroys the requested post" do
+        record
+        expect {
+          delete admin_post_url(record)
+        }.to change(Post, :count).by(-1)
+      end
+
+      it "redirects to the posts list" do
+        delete admin_post_url(record)
+        expect(response).to redirect_to(admin_posts_url)
       end
     end
   end

--- a/spec/routing/admin/posts_routing_spec.rb
+++ b/spec/routing/admin/posts_routing_spec.rb
@@ -1,0 +1,32 @@
+require "rails_helper"
+
+RSpec.describe Admin::PostsController, type: :routing do
+  describe "routing" do
+    it "routes to #index" do
+      expect(get: "/admin/posts").to route_to("admin/posts#index")
+    end
+
+    it "routes to #show" do
+      expect(get: "/admin/posts/1").to route_to("admin/posts#show", id: "1")
+    end
+
+    it "routes to #new" do
+      expect(get: "/admin/posts/new").to route_to("admin/posts#new")
+    end
+
+    it "routes to #edit" do
+      expect(get: "/admin/posts/1/edit").to route_to("admin/posts#edit", id: "1")
+    end
+    it "routes to #create" do
+      expect(post: "/admin/posts").to route_to("admin/posts#create")
+    end
+
+    it "routes to #update" do
+      expect(patch: "/admin/posts/1").to route_to("admin/posts#update", id: "1")
+    end
+
+    it "routes to #destroy" do
+      expect(delete: "/admin/posts/1").to route_to("admin/posts#destroy", id: "1")
+    end
+  end
+end

--- a/spec/support/shared_contexts/admin_login.rb
+++ b/spec/support/shared_contexts/admin_login.rb
@@ -1,0 +1,7 @@
+RSpec.shared_context 'admin logged in' do
+  let(:admin) { create(:account, password: 'P@SSw0rD') }
+
+  before do
+    post('/auth/admin/login', params: { email: admin.email, password:  'P@SSw0rD' })
+  end
+end

--- a/spec/views/admin/posts/edit.html.tailwindcss_spec.rb
+++ b/spec/views/admin/posts/edit.html.tailwindcss_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe "posts/edit", type: :view do
+RSpec.describe "admin/posts/edit", type: :view do
   let(:post) {
     Post.create!(
       title: "MyString",
@@ -14,18 +14,15 @@ RSpec.describe "posts/edit", type: :view do
     assign(:post, post)
   end
 
-  # Fix it when admins will be able to edit
-  xit "renders the edit post form" do
+  it "renders the edit post form" do
     render
 
-    assert_select "form[action=?][method=?]", post_path(post), "post" do
+    assert_select "form[action=?][method=?]", admin_post_path(post), "post" do
       assert_select "input[name=?]", "post[title]"
 
       assert_select "textarea[name=?]", "post[summary]"
 
       assert_select "textarea[name=?]", "post[body]"
-
-      assert_select "input[name=?]", "post[visitor_count]"
     end
   end
 end

--- a/spec/views/admin/posts/index.html.tailwindcss_spec.rb
+++ b/spec/views/admin/posts/index.html.tailwindcss_spec.rb
@@ -1,0 +1,31 @@
+require 'rails_helper'
+
+RSpec.describe "admin/posts/index", type: :view do
+  before(:each) do
+    assign(:posts, [
+      create(
+        :post,
+        :published,
+        title: "Title",
+        summary: "MyText",
+        body: "MyText",
+        visitor_count: 2
+      ),
+      create(
+        :post,
+        title: "Title",
+        summary: "MyText",
+        body: "MyText",
+        visitor_count: 2
+      )
+    ])
+  end
+
+  it "renders a list of posts" do
+    render
+    cell_selector = 'div>p'
+    assert_select cell_selector, text: Regexp.new("Title".to_s), count: 2
+    assert_select cell_selector, text: Regexp.new("MyText".to_s), count: 2
+    assert_select cell_selector, text: Regexp.new("MyText".to_s), count: 2
+  end
+end

--- a/spec/views/admin/posts/new.html.tailwindcss_spec.rb
+++ b/spec/views/admin/posts/new.html.tailwindcss_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe "posts/new", type: :view do
+RSpec.describe "admin/posts/new", type: :view do
   before(:each) do
     assign(:post, Post.new(
       title: "MyString",
@@ -10,18 +10,15 @@ RSpec.describe "posts/new", type: :view do
     ))
   end
 
-  # Fix it when admins will be able to create new posts
-  xit "renders new post form" do
+  it "renders new post form" do
     render
 
-    assert_select "form[action=?][method=?]", posts_path, "post" do
+    assert_select "form[action=?][method=?]", admin_posts_path, "post" do
       assert_select "input[name=?]", "post[title]"
 
       assert_select "textarea[name=?]", "post[summary]"
 
       assert_select "textarea[name=?]", "post[body]"
-
-      assert_select "input[name=?]", "post[visitor_count]"
     end
   end
 end

--- a/spec/views/admin/posts/show.html.tailwindcss_spec.rb
+++ b/spec/views/admin/posts/show.html.tailwindcss_spec.rb
@@ -1,0 +1,19 @@
+require 'rails_helper'
+
+RSpec.describe "admin/posts/show", type: :view do
+  before(:each) do
+    assign(:post, create(
+      :post,
+      title: "Title",
+      summary: "MyText",
+      body: "MyText",
+    ))
+  end
+
+  it "renders attributes in <p>" do
+    render
+    expect(rendered).to match(/Title/)
+    expect(rendered).to match(/MyText/)
+    expect(rendered).to match(/MyText/)
+  end
+end


### PR DESCRIPTION
**Description**

Add the `rodauth-rails` gem for admin authentication. For now I configured only a basic account setup with login/logout. Later I plan to add two factor authentication for admins. The main model and table is called `Account`, as I'm not sure if I'll add standard user accounts later (for commenting for example) or not. Therefore I didn't want to deviate much from the base setup, and wanted to keep my future options open.

I also added/fixed the views for admins to manage the posts.