### PR TITLE
Add publish unpublish

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -68,5 +68,6 @@ end
 
 group :test do
   gem "faker", "~> 3.5"
+  gem "rails-controller-testing", "~> 1.0"
   gem "shoulda-matchers", "~> 6.4"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -226,6 +226,10 @@ GEM
       activesupport (= 8.0.1)
       bundler (>= 1.15.0)
       railties (= 8.0.1)
+    rails-controller-testing (1.0.5)
+      actionpack (>= 5.0.1.rc1)
+      actionview (>= 5.0.1.rc1)
+      activesupport (>= 5.0.1.rc1)
     rails-dom-testing (2.2.0)
       activesupport (>= 5.0.0)
       minitest
@@ -402,6 +406,7 @@ DEPENDENCIES
   propshaft
   puma (>= 5.0)
   rails (~> 8.0.1)
+  rails-controller-testing (~> 1.0)
   rodauth-rails (~> 2.0)
   rspec-rails (~> 7.1)
   rubocop-rails-omakase

--- a/app/controllers/admin/posts_controller.rb
+++ b/app/controllers/admin/posts_controller.rb
@@ -63,7 +63,7 @@ module Admin
       if @post.published? || @post.publish
         redirect_to admin_posts_path
       else
-        redirect_to edit_admin_post_path(@post)
+        render :edit, status: :unprocessable_entity
       end
     end
 

--- a/app/controllers/admin/posts_controller.rb
+++ b/app/controllers/admin/posts_controller.rb
@@ -1,6 +1,6 @@
 module Admin
   class PostsController < ApplicationController
-    before_action :set_post, only: %i[ show edit update destroy ]
+    before_action :set_post, only: %i[ show edit update destroy publish unpublish ]
 
     # GET /posts or /posts.json
     def index
@@ -57,6 +57,20 @@ module Admin
           redirect_to admin_posts_path, status: :see_other, notice: "Post got destroyed."
         }
       end
+    end
+
+    def publish
+      if @post.published? || @post.publish
+        redirect_to admin_posts_path
+      else
+        redirect_to edit_admin_post_path(@post)
+      end
+    end
+
+    def unpublish
+      @post.unpublish if @post.published?
+
+      redirect_to admin_posts_path
     end
 
     private

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -36,11 +36,11 @@ class Post < ApplicationRecord
     published_at.present?
   end
 
-  def publish!
+  def publish
     update(published_at: Time.current)
   end
 
-  def unpublish!
+  def unpublish
     update(published_at: nil)
   end
 

--- a/app/views/admin/posts/_form.html.erb
+++ b/app/views/admin/posts/_form.html.erb
@@ -26,11 +26,6 @@
     <%= form.textarea :body, rows: 4, class: "block shadow rounded-md border border-gray-400 outline-none px-3 py-2 mt-2 w-full" %>
   </div>
 
-  <div class="my-5">
-    <%= form.label :published_at %>
-    <%= form.datetime_field :published_at, class: "block shadow rounded-md border border-gray-400 outline-none px-3 py-2 mt-2 w-full" %>
-  </div>
-
   <div class="inline">
     <%= form.submit class: "rounded-lg py-3 px-5 bg-blue-600 text-white inline-block font-medium cursor-pointer" %>
   </div>

--- a/app/views/admin/posts/index.html.erb
+++ b/app/views/admin/posts/index.html.erb
@@ -17,16 +17,12 @@
       <p>
         <%= link_to "Edit", edit_admin_post_path(post), class: "ml-2 rounded-lg py-3 px-5 bg-gray-100 inline-block font-medium" %>
       </p>
-      <p>
-        <% if post.published? %>
-          <%= button_to "Unpublish", unpublish_admin_post_path(post), method: :patch, class: "ml-2 rounded-lg py-3 px-5 bg-gray-100 inline-block font-medium" %>
-        <% else %>
-          <%= button_to "Publish", publish_admin_post_path(post), method: :patch, class: "ml-2 rounded-lg py-3 px-5 bg-gray-100 inline-block font-medium" %>
-        <% end %>
-      </p>
-      <p>
-        <%= button_to "Destroy", admin_post_path(post), method: :delete, class: "mt-2 rounded-lg py-3 px-5 bg-red-500 text-white font-medium" %>
-      </p>
+      <% if post.published? %>
+        <%= button_to "Unpublish", unpublish_admin_post_path(post), method: :patch, class: "ml-2 rounded-lg py-3 px-5 bg-gray-100 inline-block font-medium" %>
+      <% else %>
+        <%= button_to "Publish", publish_admin_post_path(post), method: :patch, class: "ml-2 rounded-lg py-3 px-5 bg-gray-100 inline-block font-medium" %>
+      <% end %>
+      <%= button_to "Destroy", admin_post_path(post), method: :delete, class: "mt-2 rounded-lg py-3 px-5 bg-red-500 text-white font-medium" %>
     <% end %>
   </div>
 </div>

--- a/app/views/admin/posts/index.html.erb
+++ b/app/views/admin/posts/index.html.erb
@@ -5,11 +5,27 @@
 
   <% content_for :title, "Posts" %>
 
+  <p>
+    <%= link_to "New post", new_admin_post_path, class: "ml-2 rounded-lg py-3 px-5 bg-gray-100 inline-block font-medium" %>
+  </p>
   <div id="posts" class="min-w-full">
     <% @posts.each do |post| %>
       <%= render "post_card", post: post %>
       <p>
-        <%= link_to "Show this post", admin_post_path(post), class: "ml-2 rounded-lg py-3 px-5 bg-gray-100 inline-block font-medium" %>
+        <%= link_to "Show", admin_post_path(post), class: "ml-2 rounded-lg py-3 px-5 bg-gray-100 inline-block font-medium" %>
+      </p>
+      <p>
+        <%= link_to "Edit", edit_admin_post_path(post), class: "ml-2 rounded-lg py-3 px-5 bg-gray-100 inline-block font-medium" %>
+      </p>
+      <p>
+        <% if post.published? %>
+          <%= button_to "Unpublish", unpublish_admin_post_path(post), method: :patch, class: "ml-2 rounded-lg py-3 px-5 bg-gray-100 inline-block font-medium" %>
+        <% else %>
+          <%= button_to "Publish", publish_admin_post_path(post), method: :patch, class: "ml-2 rounded-lg py-3 px-5 bg-gray-100 inline-block font-medium" %>
+        <% end %>
+      </p>
+      <p>
+        <%= button_to "Destroy", admin_post_path(post), method: :delete, class: "mt-2 rounded-lg py-3 px-5 bg-red-500 text-white font-medium" %>
       </p>
     <% end %>
   </div>

--- a/app/views/admin/posts/show.html.erb
+++ b/app/views/admin/posts/show.html.erb
@@ -9,7 +9,7 @@
     <%= link_to "Edit this post", edit_admin_post_path(@post), class: "mt-2 rounded-lg py-3 px-5 bg-gray-100 inline-block font-medium" %>
     <%= link_to "Back to posts", admin_posts_path, class: "ml-2 rounded-lg py-3 px-5 bg-gray-100 inline-block font-medium" %>
     <div class="inline-block ml-2">
-      <%= button_to "Destroy this post", admin_post_path(@post), method: :delete, class: "mt-2 rounded-lg py-3 px-5 bg-gray-100 font-medium" %>
+      <%= button_to "Destroy this post", admin_post_path(@post), method: :delete, class: "mt-2 rounded-lg py-3 px-5 bg-red-500 text-white font-medium" %>
     </div>
   </div>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,7 +2,12 @@ Rails.application.routes.draw do
   resources :posts, only: %i[index show]
 
   namespace :admin do
-    resources :posts
+    resources :posts do
+      member do
+        patch :publish
+        patch :unpublish
+      end
+    end
   end
 
   # Reveal health status on /up that returns 200 if the app boots with no exceptions, otherwise 500.

--- a/spec/models/post_spec.rb
+++ b/spec/models/post_spec.rb
@@ -80,17 +80,17 @@ RSpec.describe Post, type: :model do
     end
   end
 
-  describe '#publish!' do
+  describe '#publish' do
     it 'sets published time' do
-      expect { post.publish! }.to change(post, :published?).from(false).to(true)
+      expect { post.publish }.to change(post, :published?).from(false).to(true)
     end
   end
 
-  describe '#unpublish!' do
+  describe '#unpublish' do
     subject(:post) { build(:post, :published) }
 
     it 'removes published time' do
-      expect { post.unpublish! }.to change(post, :published?).from(true).to(false)
+      expect { post.unpublish }.to change(post, :published?).from(true).to(false)
     end
   end
 

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -69,4 +69,5 @@ RSpec.configure do |config|
   # config.filter_gems_from_backtrace("gem name")
 
   config.include ActiveSupport::Testing::TimeHelpers
+  config.include Rails::Controller::Testing::TemplateAssertions, type: :request
 end

--- a/spec/requests/admin/posts_spec.rb
+++ b/spec/requests/admin/posts_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe "/admin/posts", type: :request do
 
     describe "GET /new" do
       it "redirects to the login page" do
-        get new_admin_post_url(record)
+        get new_admin_post_url
         expect(response).to redirect_to('/auth/admin/login')
       end
     end
@@ -88,6 +88,34 @@ RSpec.describe "/admin/posts", type: :request do
 
       it "redirects to the login page" do
         delete admin_post_url(record)
+        expect(response).to redirect_to('/auth/admin/login')
+      end
+    end
+
+    describe "PATCH /publish" do
+      let(:record) { create(:post) }
+
+      it "does not update the requested post" do
+        patch publish_admin_post_url(record)
+        expect(record.reload).not_to be_published
+      end
+
+      it "redirects to the login page" do
+        patch publish_admin_post_url(record)
+        expect(response).to redirect_to('/auth/admin/login')
+      end
+    end
+
+    describe "PATCH /unpublish" do
+      let(:record) { create(:post, :published) }
+
+      it "does not update the requested post" do
+        patch unpublish_admin_post_url(record)
+        expect(record.reload).to be_published
+      end
+
+      it "redirects to the login page" do
+        patch unpublish_admin_post_url(record)
         expect(response).to redirect_to('/auth/admin/login')
       end
     end
@@ -181,6 +209,78 @@ RSpec.describe "/admin/posts", type: :request do
       it "redirects to the posts list" do
         delete admin_post_url(record)
         expect(response).to redirect_to(admin_posts_url)
+      end
+    end
+
+    describe "PATCH /publish" do
+      context "when the post is valid" do
+        let(:record) { create(:post) }
+
+        it "updates the requested post" do
+          patch publish_admin_post_url(record)
+          expect(record.reload).to be_published
+        end
+
+        it "redirects to posts" do
+          patch publish_admin_post_url(record)
+          expect(response).to redirect_to(admin_posts_url)
+        end
+      end
+
+      context "when the post is invalid" do
+        let(:record) { create(:post, title: '') }
+
+        it "updates the requested post" do
+          patch publish_admin_post_url(record)
+          expect(record.reload).not_to be_published
+        end
+
+        it "redirects to the edit page" do
+          patch publish_admin_post_url(record)
+          expect(response).to redirect_to(edit_admin_post_url(record))
+        end
+      end
+
+      context "when the post is already publisjed" do
+        let(:record) { create(:post, :published) }
+
+        it "keeps the post published" do
+          patch publish_admin_post_url(record)
+          expect(record.reload).to be_published
+        end
+
+        it "redirects to posts" do
+          patch publish_admin_post_url(record)
+          expect(response).to redirect_to(admin_posts_url)
+        end
+      end
+    end
+
+    describe "PATCH /unpublish" do
+      let(:record) { create(:post, :published) }
+
+      it "updates the requested post" do
+        patch unpublish_admin_post_url(record)
+        expect(record.reload).not_to be_published
+      end
+
+      it "redirects to posts" do
+        patch unpublish_admin_post_url(record)
+        expect(response).to redirect_to(admin_posts_url)
+      end
+
+      context "when the post is not published" do
+        let(:record) { create(:post) }
+
+        it "keeps the record unpublished" do
+          patch unpublish_admin_post_url(record)
+          expect(record.reload).not_to be_published
+        end
+
+        it "redirects to posts" do
+          patch unpublish_admin_post_url(record)
+          expect(response).to redirect_to(admin_posts_url)
+        end
       end
     end
   end

--- a/spec/requests/admin/posts_spec.rb
+++ b/spec/requests/admin/posts_spec.rb
@@ -235,13 +235,14 @@ RSpec.describe "/admin/posts", type: :request do
           expect(record.reload).not_to be_published
         end
 
-        it "redirects to the edit page" do
+        it "renders the edit page with the error" do
           patch publish_admin_post_url(record)
-          expect(response).to redirect_to(edit_admin_post_url(record))
+          assert_template 'admin/posts/edit'
+          expect(response.body).to include("Title can&#39;t be blank")
         end
       end
 
-      context "when the post is already publisjed" do
+      context "when the post is already published" do
         let(:record) { create(:post, :published) }
 
         it "keeps the post published" do

--- a/spec/routing/admin/posts_routing_spec.rb
+++ b/spec/routing/admin/posts_routing_spec.rb
@@ -28,5 +28,13 @@ RSpec.describe Admin::PostsController, type: :routing do
     it "routes to #destroy" do
       expect(delete: "/admin/posts/1").to route_to("admin/posts#destroy", id: "1")
     end
+
+    it "routes to #publish" do
+      expect(patch: "/admin/posts/1/publish").to route_to("admin/posts#publish", id: "1")
+    end
+
+    it "routes to #unpublish" do
+      expect(patch: "/admin/posts/1/unpublish").to route_to("admin/posts#unpublish", id: "1")
+    end
   end
 end

--- a/spec/views/admin/posts/index.html.tailwindcss_spec.rb
+++ b/spec/views/admin/posts/index.html.tailwindcss_spec.rb
@@ -24,8 +24,15 @@ RSpec.describe "admin/posts/index", type: :view do
   it "renders a list of posts" do
     render
     cell_selector = 'div>p'
-    assert_select cell_selector, text: Regexp.new("Title".to_s), count: 2
-    assert_select cell_selector, text: Regexp.new("MyText".to_s), count: 2
-    assert_select cell_selector, text: Regexp.new("MyText".to_s), count: 2
+    assert_select cell_selector, text: Regexp.new("Title"), count: 2
+    assert_select cell_selector, text: Regexp.new("MyText"), count: 2
+    assert_select cell_selector, text: Regexp.new("MyText"), count: 2
+    assert_select 'button', text: Regexp.new("Unpublish"), count: 1
+    assert_select 'button', text: Regexp.new("Publish"), count: 1
+  end
+
+  it "renders the new post button" do
+    render
+    expect(rendered).to include('New post')
   end
 end


### PR DESCRIPTION
**Description**

Add post publish and unpublish actions to the admin features. Admins can publish and unpublish posts from the index page. If the publishing fails due to a validation error then the `edit` template is rendered showing the errors.

An improvement could be to add a "Publish" checkbox to the form, so new posts could be published right away, and posts can be published while edited. Now I need to create/edit the post first, look for it on the front page and publish it there. Although this is not a priority for now, with this change I have a way to publish posts.