### PR TITLE
Add Markdown support

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -38,6 +38,7 @@ gem "thruster", require: false
 
 # Required by Rodauth
 gem "bcrypt", "~> 3.1"
+gem "redcarpet", "~> 3.6"
 gem "rodauth-rails", "~> 2.0"
 gem "sequel-activerecord_connection", "~> 2.0"
 gem "tilt", "~> 2.4"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -253,6 +253,7 @@ GEM
     rake (13.2.1)
     rdoc (6.10.0)
       psych (>= 4.0.0)
+    redcarpet (3.6.0)
     regexp_parser (2.9.3)
     reline (0.6.0)
       io-console (~> 0.5)
@@ -412,6 +413,7 @@ DEPENDENCIES
   puma (>= 5.0)
   rails (~> 8.0.1)
   rails-controller-testing (~> 1.0)
+  redcarpet (~> 3.6)
   rodauth-rails (~> 2.0)
   rspec-rails (~> 7.1)
   rubocop-rails-omakase

--- a/app/helpers/markdown_helper.rb
+++ b/app/helpers/markdown_helper.rb
@@ -16,6 +16,27 @@ module MarkdownHelper
           shadow-md shadow-nord8"
         ><code class="language-#{language}">#{code}</code></pre>)
     end
+
+    def codespan(code)
+      %(<code class="text-nord9">#{code}</code>)
+    end
+
+    def header(header, header_level)
+      case header_level
+      when 1
+        %(<h1 class="my-5 text-5xl">#{header}</h1>)
+      when 2
+        %(<h2 class="my-3 text-4xl">#{header}</h2>)
+      else
+        super
+      end
+    end
+
+    def link(link, title, content)
+      %(<a href="#{link}" target="_blank" class="
+          border-r border-b px-2 ml-px hover:border hover:border-nord8 hover:m-0"
+        >#{content}</a>)
+    end
   end
 
   def renderer

--- a/app/helpers/markdown_helper.rb
+++ b/app/helpers/markdown_helper.rb
@@ -1,0 +1,18 @@
+module MarkdownHelper
+  def md(text)
+    renderer.render(text).html_safe
+  end
+
+  private
+
+  def renderer
+    @renderer ||= Redcarpet::Markdown.new(
+      Redcarpet::Render::HTML,
+      autolink: true,
+      filter_html: true,
+      with_toc_data: true,
+      prettify: true,
+      fenced_code_blocks: true
+    )
+  end
+end

--- a/app/helpers/markdown_helper.rb
+++ b/app/helpers/markdown_helper.rb
@@ -1,18 +1,28 @@
 module MarkdownHelper
   def md(text)
-    renderer.render(text).html_safe
+    markdown.render(text).html_safe
   end
 
   private
 
+  def markdown
+    @markdown ||= Redcarpet::Markdown.new(renderer, fenced_code_blocks: true)
+  end
+
+  class CustomRenderer < Redcarpet::Render::HTML
+    def block_code(code, language)
+      %(<pre class="
+          my-5 border-solid border-2 border-nord8 rounded-md
+          shadow-md shadow-nord8"
+        ><code class="language-#{language}">#{code}</code></pre>)
+    end
+  end
+
   def renderer
-    @renderer ||= Redcarpet::Markdown.new(
-      Redcarpet::Render::HTML,
+    @renderer ||= CustomRenderer.new(
       autolink: true,
       filter_html: true,
-      with_toc_data: true,
-      prettify: true,
-      fenced_code_blocks: true
+      with_toc_data: true
     )
   end
 end

--- a/app/helpers/markdown_helper.rb
+++ b/app/helpers/markdown_helper.rb
@@ -10,17 +10,6 @@ module MarkdownHelper
   end
 
   class CustomRenderer < Redcarpet::Render::HTML
-    def block_code(code, language)
-      %(<pre class="
-          my-5 border-solid border-2 border-nord8 rounded-md
-          shadow-md shadow-nord8"
-        ><code class="language-#{language}">#{code}</code></pre>)
-    end
-
-    def codespan(code)
-      %(<code class="text-nord9">#{code}</code>)
-    end
-
     def header(header, header_level)
       case header_level
       when 1
@@ -32,9 +21,21 @@ module MarkdownHelper
       end
     end
 
+    def block_code(code, language)
+      %(<pre class="
+          my-5 border-solid border-2 border-nord8 rounded-md shadow-md
+          shadow-nord8"
+        ><code class="language-#{language}">#{code}</code></pre>)
+    end
+
+    def codespan(code)
+      %(<code class="text-nord9">#{code}</code>)
+    end
+
     def link(link, title, content)
       %(<a href="#{link}" target="_blank" class="
-          border-r border-b px-2 ml-px hover:border hover:border-nord8 hover:m-0"
+          border-r border-b px-2 ml-px hover:border hover:border-nord8
+          hover:m-0"
         >#{content}</a>)
     end
   end

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -1,3 +1,5 @@
 // Configure your import map in config/importmap.rb. Read more: https://github.com/rails/importmap-rails
 import "@hotwired/turbo-rails"
 import "controllers"
+
+hljs.highlightAll();

--- a/app/views/admin/posts/_post.html.erb
+++ b/app/views/admin/posts/_post.html.erb
@@ -5,18 +5,18 @@
   </p>
 
   <p class="my-5">
+    <strong class="block font-medium mb-1">Published at:</strong>
+    <%= post.published_at %>
+  </p>
+
+  <p class="my-5">
     <strong class="block font-medium mb-1">Summary:</strong>
     <%= post.summary %>
   </p>
 
   <p class="my-5">
     <strong class="block font-medium mb-1">Body:</strong>
-    <%= post.body %>
-  </p>
-
-  <p class="my-5">
-    <strong class="block font-medium mb-1">Published at:</strong>
-    <%= post.published_at %>
+    <%= md(post.body) %>
   </p>
 
 </div>

--- a/app/views/admin/posts/show.html.erb
+++ b/app/views/admin/posts/show.html.erb
@@ -6,10 +6,12 @@
 
     <%= render "admin/posts/post", post: @post %>
 
-    <%= link_to "Edit this post", edit_admin_post_path(@post), class: "button" %>
-    <%= link_to "Back to posts", admin_posts_path, class: "button" %>
-    <div class="inline-block ml-2">
-      <%= button_to "Destroy this post", admin_post_path(@post), method: :delete, class: "button-danger" %>
+    <div class="mt-5">
+      <%= link_to "Edit this post", edit_admin_post_path(@post), class: "button" %>
+      <%= link_to "Back to posts", admin_posts_path, class: "button" %>
+      <div class="inline-block ml-2">
+        <%= button_to "Destroy this post", admin_post_path(@post), method: :delete, class: "button-danger" %>
+      </div>
     </div>
   </div>
 </div>

--- a/app/views/application/_sidebar.html.erb
+++ b/app/views/application/_sidebar.html.erb
@@ -2,7 +2,7 @@
     <h1 class="text-2xl my-4">Welcome!</h1>
     <p class="my-2">
       Welcome to my development blog. I plan to write about various topics related to multiple technologies.
-      (Mainly Ruby on Rails and NixOS in the beginning.) Look around in the posts on the left.
+      (Mainly Ruby on Rails and NixOS in the beginning.) Look around in the posts on the home page.
     </p>
     <p>
       <strong>Note:</strong> The website's name is not related to Meta's <code>llama</code> AI models in any way.

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -16,6 +16,10 @@
     <link rel="icon" href="/icon.png" type="image/png">
     <link rel="icon" href="/icon.svg" type="image/svg+xml">
     <link rel="apple-touch-icon" href="/icon.png">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.11.1/styles/nord.min.css">
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.11.1/highlight.min.js"></script>
+    <!-- and it's easy to individually load additional languages -->
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.11.1/languages/ruby.min.js"></script>
 
     <%# Includes all stylesheet files in app/assets/stylesheets %>
     <%= stylesheet_link_tag "tailwind", "inter-font", "data-turbo-track": "reload" %>

--- a/app/views/posts/_post.html.erb
+++ b/app/views/posts/_post.html.erb
@@ -5,7 +5,7 @@
 
   <%= render "posts/timestamps", post: post %>
 
-  <p class="my-5">
-    <%= post.body %>
-  </p>
+  <div class="my-5">
+    <%= md(post.body) %>
+  </div>
 </div>

--- a/spec/views/admin/posts/index.html.tailwindcss_spec.rb
+++ b/spec/views/admin/posts/index.html.tailwindcss_spec.rb
@@ -7,15 +7,15 @@ RSpec.describe "admin/posts/index", type: :view do
         :post,
         :published,
         title: "Title",
-        summary: "MyText",
-        body: "MyText",
+        summary: "MySummary",
+        body: "MyBody",
         visitor_count: 2
       ),
       create(
         :post,
         title: "Title",
-        summary: "MyText",
-        body: "MyText",
+        summary: "MySummary",
+        body: "MyBody",
         visitor_count: 2
       )
     ])
@@ -25,8 +25,8 @@ RSpec.describe "admin/posts/index", type: :view do
     render
     cell_selector = 'div>p'
     assert_select cell_selector, text: Regexp.new("Title"), count: 2
-    assert_select cell_selector, text: Regexp.new("MyText"), count: 2
-    assert_select cell_selector, text: Regexp.new("MyText"), count: 2
+    assert_select cell_selector, text: Regexp.new("MySummary"), count: 2
+    assert_select cell_selector, text: Regexp.new("MyBody"), count: 0
     assert_select 'button', text: Regexp.new("Unpublish"), count: 1
     assert_select 'button', text: Regexp.new("Publish"), count: 1
   end

--- a/spec/views/admin/posts/show.html.tailwindcss_spec.rb
+++ b/spec/views/admin/posts/show.html.tailwindcss_spec.rb
@@ -5,15 +5,62 @@ RSpec.describe "admin/posts/show", type: :view do
     assign(:post, create(
       :post,
       title: "Title",
-      summary: "MyText",
-      body: "MyText",
+      summary: "MySummary",
+      body: "MyBody",
     ))
   end
 
   it "renders attributes in <p>" do
     render
     expect(rendered).to match(/Title/)
-    expect(rendered).to match(/MyText/)
-    expect(rendered).to match(/MyText/)
+    expect(rendered).to match(/MySummary/)
+    expect(rendered).to match(/MyBody/)
+  end
+
+  describe 'Markdown' do
+    let(:post) do
+      create(
+        :post,
+        :published,
+        title: "Title",
+        summary: "MySummary",
+        body: <<-BODY
+# Summary
+
+This is a post of sample code
+
+```
+class Foo; def bar; puts Hello bar end end
+```
+
+## Explanation
+
+The above `bar` method prints the string "Hello bar"
+        BODY
+      )
+    end
+    before(:each) do
+      assign(:post, post)
+    end
+
+    it 'renders main headers' do
+      render
+      expect(rendered).to match(/<h1.*>Summary<\/h1>/)
+    end
+
+    it 'renders sub headers' do
+      render
+      expect(rendered).to match(/<h2.*>Explanation<\/h2>/)
+    end
+
+    it 'renders code blocks' do
+      render
+      expect(rendered).to match(/<pre.*><code.*>class Foo; def bar.*<\/code><\/pre>/m)
+    end
+
+    it 'renders inline code' do
+      render
+      expect(rendered).to match(/<code.*>bar<\/code>/)
+    end
   end
 end

--- a/spec/views/posts/index.html.tailwindcss_spec.rb
+++ b/spec/views/posts/index.html.tailwindcss_spec.rb
@@ -7,16 +7,16 @@ RSpec.describe "posts/index", type: :view do
         :post,
         :published,
         title: "Title",
-        summary: "MyText",
-        body: "MyText",
+        summary: "MySummary",
+        body: "MyBody",
         visitor_count: 2
       ),
       create(
         :post,
         :published,
         title: "Title",
-        summary: "MyText",
-        body: "MyText",
+        summary: "MySummary",
+        body: "MyBody",
         visitor_count: 2
       )
     ])
@@ -26,7 +26,7 @@ RSpec.describe "posts/index", type: :view do
     render
     cell_selector = 'div>p'
     assert_select 'h1', text: Regexp.new("Title".to_s), count: 2
-    assert_select cell_selector, text: Regexp.new("MyText".to_s), count: 2
-    assert_select cell_selector, text: Regexp.new("MyText".to_s), count: 2
+    assert_select cell_selector, text: Regexp.new("MySummary".to_s), count: 2
+    assert_select cell_selector, text: Regexp.new("MyBody".to_s), count: 0
   end
 end

--- a/spec/views/posts/show.html.tailwindcss_spec.rb
+++ b/spec/views/posts/show.html.tailwindcss_spec.rb
@@ -6,15 +6,15 @@ RSpec.describe "posts/show", type: :view do
       :post,
       :published,
       title: "Title",
-      summary: "MyText",
-      body: "MyText",
+      summary: "MySummary",
+      body: "MyBody",
     ))
   end
 
   it "renders attributes in <p>" do
     render
     expect(rendered).to match(/Title/)
-    expect(rendered).to match(/MyText/)
-    expect(rendered).to match(/MyText/)
+    expect(rendered).to match(/MyBody/)
+    expect(rendered).not_to match(/MySummary/)
   end
 end

--- a/spec/views/posts/show.html.tailwindcss_spec.rb
+++ b/spec/views/posts/show.html.tailwindcss_spec.rb
@@ -17,4 +17,51 @@ RSpec.describe "posts/show", type: :view do
     expect(rendered).to match(/MyBody/)
     expect(rendered).not_to match(/MySummary/)
   end
+
+  describe 'Markdown' do
+    let(:post) do
+      create(
+        :post,
+        :published,
+        title: "Title",
+        summary: "MySummary",
+        body: <<-BODY
+# Summary
+
+This is a post of sample code
+
+```
+class Foo; def bar; puts Hello bar end end
+```
+
+## Explanation
+
+The above `bar` method prints the string "Hello bar"
+        BODY
+      )
+    end
+    before(:each) do
+      assign(:post, post)
+    end
+
+    it 'renders main headers' do
+      render
+      expect(rendered).to match(/<h1.*>Summary<\/h1>/)
+    end
+
+    it 'renders sub headers' do
+      render
+      expect(rendered).to match(/<h2.*>Explanation<\/h2>/)
+    end
+
+    it 'renders code blocks' do
+      render
+      expect(rendered).to match(/<pre.*><code.*>class Foo; def bar.*<\/code><\/pre>/m)
+    end
+
+    it 'renders inline code' do
+      render
+      expect(rendered).to match(/<code.*>bar<\/code>/)
+    end
+  end
 end


### PR DESCRIPTION
**Description**

Render posts written in Markdown using the `redcarpet` gem and `highlight.js` for syntax highlighting inside the `code` blocks.